### PR TITLE
chore: ignore local-only skills and editor folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ obj/
 tmp/
 TestResults/
 artifacts/
+publish/
+skills/
+.idea/
+.fleet/
+.history/
+.DS_Store


### PR DESCRIPTION
## Related
Closes #10

## Summary
- ignore project-local `skills/`
- ignore `publish/`
- ignore local editor metadata folders such as `.idea/`, `.fleet/`, `.history/`, and `.DS_Store`

## Testing
- Not run

## UI Notes
- No UI changes

## Attribution
- Generated with Codex