### PR TITLE
refactor: modernize core app stability

### DIFF
--- a/src/WindowsNotch.App/App.xaml.cs
+++ b/src/WindowsNotch.App/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
 using WindowsNotch.App.Services;
@@ -7,51 +8,115 @@ namespace WindowsNotch.App;
 
 public partial class App : Application
 {
+    private int _isHandlingFatalException;
+
     protected override void OnStartup(StartupEventArgs e)
     {
+        base.OnStartup(e);
+
         DispatcherUnhandledException += App_DispatcherUnhandledException;
         AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-        base.OnStartup(e);
+        TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        DispatcherUnhandledException -= App_DispatcherUnhandledException;
+        AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
+        TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
+        base.OnExit(e);
     }
 
     private void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
     {
-        var logPath = WriteCrashLog(e.Exception);
-        MessageBox.Show(
-            $"WindowsNotch crashed.\n\n{e.Exception}\n\nLog:\n{logPath}",
-            "WindowsNotch",
-            MessageBoxButton.OK,
-            MessageBoxImage.Error);
-
+        ShowFatalError(e.Exception, shutdownAfterClose: true);
         e.Handled = true;
-        Shutdown(-1);
     }
 
     private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
         var exception = e.ExceptionObject as Exception ?? new Exception("Unknown unhandled exception.");
-        var logPath = WriteCrashLog(exception);
-
-        MessageBox.Show(
-            $"WindowsNotch crashed.\n\n{exception}\n\nLog:\n{logPath}",
-            "WindowsNotch",
-            MessageBoxButton.OK,
-            MessageBoxImage.Error);
+        ShowFatalError(exception, shutdownAfterClose: e.IsTerminating);
     }
 
-    private static string WriteCrashLog(Exception exception)
+    private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
     {
-        Directory.CreateDirectory(AppPaths.LogRoot);
+        ShowFatalError(e.Exception, shutdownAfterClose: false);
+        e.SetObserved();
+    }
 
-        var logPath = Path.Combine(AppPaths.LogRoot, $"crash-{DateTime.Now:yyyyMMdd-HHmmss}.log");
-        var logText =
-            $"Timestamp: {DateTime.Now:O}{Environment.NewLine}" +
-            $"OS: {Environment.OSVersion}{Environment.NewLine}" +
-            $"Process: {Environment.ProcessPath}{Environment.NewLine}" +
-            Environment.NewLine +
-            exception;
+    private void ShowFatalError(Exception exception, bool shutdownAfterClose)
+    {
+        if (Interlocked.CompareExchange(ref _isHandlingFatalException, 1, 0) != 0)
+        {
+            return;
+        }
 
-        File.WriteAllText(logPath, logText);
-        return logPath;
+        var logPath = TryWriteCrashLog(exception);
+        var message =
+            $"WindowsNotch crashed.\n\n{exception}\n\nLog:\n{logPath}";
+
+        void ShowMessage()
+        {
+            MessageBox.Show(
+                message,
+                "WindowsNotch",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+
+            if (shutdownAfterClose)
+            {
+                Shutdown(-1);
+            }
+        }
+
+        try
+        {
+            if (Dispatcher.CheckAccess())
+            {
+                ShowMessage();
+                return;
+            }
+
+            Dispatcher.Invoke(ShowMessage);
+        }
+        catch
+        {
+            MessageBox.Show(
+                message,
+                "WindowsNotch",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+        finally
+        {
+            if (!shutdownAfterClose)
+            {
+                Interlocked.Exchange(ref _isHandlingFatalException, 0);
+            }
+        }
+    }
+
+    private static string TryWriteCrashLog(Exception exception)
+    {
+        try
+        {
+            Directory.CreateDirectory(AppPaths.LogRoot);
+
+            var logPath = Path.Combine(AppPaths.LogRoot, $"crash-{DateTime.Now:yyyyMMdd-HHmmss}.log");
+            var logText =
+                $"Timestamp: {DateTime.Now:O}{Environment.NewLine}" +
+                $"OS: {Environment.OSVersion}{Environment.NewLine}" +
+                $"Process: {Environment.ProcessPath}{Environment.NewLine}" +
+                Environment.NewLine +
+                exception;
+
+            File.WriteAllText(logPath, logText);
+            return logPath;
+        }
+        catch (Exception logException)
+        {
+            return $"Crash log could not be written: {logException.Message}";
+        }
     }
 }

--- a/src/WindowsNotch.App/Services/AppSettingsService.cs
+++ b/src/WindowsNotch.App/Services/AppSettingsService.cs
@@ -6,6 +6,11 @@ namespace WindowsNotch.App.Services;
 
 public sealed class AppSettingsService
 {
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
     public AppSettings Load()
     {
         try
@@ -30,14 +35,21 @@ public sealed class AppSettingsService
             ?? throw new InvalidOperationException("Settings directory could not be resolved.");
 
         Directory.CreateDirectory(settingsDirectory);
+        var temporaryFilePath = Path.Combine(settingsDirectory, $"{Path.GetFileName(AppPaths.SettingsFilePath)}.tmp");
 
-        var json = JsonSerializer.Serialize(
-            settings,
-            new JsonSerializerOptions
+        var json = JsonSerializer.Serialize(settings, JsonSerializerOptions);
+
+        try
+        {
+            File.WriteAllText(temporaryFilePath, json);
+            File.Move(temporaryFilePath, AppPaths.SettingsFilePath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryFilePath))
             {
-                WriteIndented = true,
-            });
-
-        File.WriteAllText(AppPaths.SettingsFilePath, json);
+                File.Delete(temporaryFilePath);
+            }
+        }
     }
 }

--- a/src/WindowsNotch.App/Services/MediaSessionService.cs
+++ b/src/WindowsNotch.App/Services/MediaSessionService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using Windows.Media.Control;
 using Windows.Storage.Streams;
 using WindowsNotch.App.Models;
@@ -7,23 +8,35 @@ namespace WindowsNotch.App.Services;
 
 public sealed class MediaSessionService : IDisposable
 {
+    private readonly SemaphoreSlim _publishStateLock = new(1, 1);
     private GlobalSystemMediaTransportControlsSessionManager? _manager;
     private GlobalSystemMediaTransportControlsSession? _currentSession;
+    private int _publishStateVersion;
+    private bool _isDisposed;
 
     public event EventHandler<NowPlayingState>? StateChanged;
 
     public async Task InitializeAsync()
     {
+        ThrowIfDisposed();
+
+        if (_manager is not null)
+        {
+            return;
+        }
+
         _manager = await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
         _manager.CurrentSessionChanged += Manager_CurrentSessionChanged;
         _manager.SessionsChanged += Manager_SessionsChanged;
 
-        AttachToSession(_manager.GetCurrentSession() ?? _manager.GetSessions().FirstOrDefault());
+        AttachToSession(GetCurrentOrFirstSession(_manager));
         await PublishStateAsync();
     }
 
     public async Task TogglePlayPauseAsync()
     {
+        ThrowIfDisposed();
+
         if (_currentSession is null)
         {
             return;
@@ -35,6 +48,8 @@ public sealed class MediaSessionService : IDisposable
 
     public async Task SkipNextAsync()
     {
+        ThrowIfDisposed();
+
         if (_currentSession is null)
         {
             return;
@@ -46,6 +61,8 @@ public sealed class MediaSessionService : IDisposable
 
     public async Task SkipPreviousAsync()
     {
+        ThrowIfDisposed();
+
         if (_currentSession is null)
         {
             return;
@@ -57,6 +74,8 @@ public sealed class MediaSessionService : IDisposable
 
     public async Task SeekAsync(TimeSpan position)
     {
+        ThrowIfDisposed();
+
         if (_currentSession is null)
         {
             return;
@@ -68,11 +87,12 @@ public sealed class MediaSessionService : IDisposable
         }
 
         await _currentSession.TryChangePlaybackPositionAsync(position.Ticks);
+        await PublishStateAsync();
     }
 
     private async void Manager_CurrentSessionChanged(GlobalSystemMediaTransportControlsSessionManager sender, CurrentSessionChangedEventArgs args)
     {
-        AttachToSession(sender.GetCurrentSession() ?? sender.GetSessions().FirstOrDefault());
+        AttachToSession(GetCurrentOrFirstSession(sender));
         await PublishStateAsync();
     }
 
@@ -80,7 +100,7 @@ public sealed class MediaSessionService : IDisposable
     {
         if (_currentSession is null || !sender.GetSessions().Contains(_currentSession))
         {
-            AttachToSession(sender.GetCurrentSession() ?? sender.GetSessions().FirstOrDefault());
+            AttachToSession(GetCurrentOrFirstSession(sender));
         }
 
         await PublishStateAsync();
@@ -103,6 +123,8 @@ public sealed class MediaSessionService : IDisposable
 
     private void AttachToSession(GlobalSystemMediaTransportControlsSession? session)
     {
+        ThrowIfDisposed();
+
         if (_currentSession is not null)
         {
             _currentSession.MediaPropertiesChanged -= CurrentSession_MediaPropertiesChanged;
@@ -122,30 +144,71 @@ public sealed class MediaSessionService : IDisposable
 
     private async Task PublishStateAsync()
     {
-        var state = await BuildStateAsync();
-        StateChanged?.Invoke(this, state);
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        var publishVersion = Interlocked.Increment(ref _publishStateVersion);
+        var lockTaken = false;
+
+        try
+        {
+            await _publishStateLock.WaitAsync();
+            lockTaken = true;
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            var state = await BuildStateAsync();
+            if (_isDisposed || publishVersion != Volatile.Read(ref _publishStateVersion))
+            {
+                return;
+            }
+
+            StateChanged?.Invoke(this, state);
+        }
+        catch
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            StateChanged?.Invoke(this, new NowPlayingState());
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                _publishStateLock.Release();
+            }
+        }
     }
 
     private async Task<NowPlayingState> BuildStateAsync()
     {
-        if (_currentSession is null)
+        var currentSession = _currentSession;
+        if (currentSession is null)
         {
             return new NowPlayingState();
         }
 
-        GlobalSystemMediaTransportControlsSessionMediaProperties? mediaProperties = null;
+        GlobalSystemMediaTransportControlsSessionMediaProperties? mediaProperties;
 
         try
         {
-            mediaProperties = await _currentSession.TryGetMediaPropertiesAsync();
+            mediaProperties = await currentSession.TryGetMediaPropertiesAsync();
         }
         catch
         {
             mediaProperties = null;
         }
 
-        var playbackInfo = _currentSession.GetPlaybackInfo();
-        var timeline = _currentSession.GetTimelineProperties();
+        var playbackInfo = currentSession.GetPlaybackInfo();
+        var timeline = currentSession.GetTimelineProperties();
         var controls = playbackInfo?.Controls;
         var title = mediaProperties?.Title;
         var artist = mediaProperties?.Artist;
@@ -164,7 +227,7 @@ public sealed class MediaSessionService : IDisposable
             Position = position,
             Duration = duration,
             CapturedAtUtc = DateTime.UtcNow,
-            SourceAppId = _currentSession.SourceAppUserModelId ?? string.Empty,
+            SourceAppId = currentSession.SourceAppUserModelId ?? string.Empty,
             ArtworkBytes = await LoadArtworkBytesAsync(mediaProperties?.Thumbnail),
         };
     }
@@ -193,6 +256,13 @@ public sealed class MediaSessionService : IDisposable
 
     public void Dispose()
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+
         if (_currentSession is not null)
         {
             _currentSession.MediaPropertiesChanged -= CurrentSession_MediaPropertiesChanged;
@@ -205,5 +275,26 @@ public sealed class MediaSessionService : IDisposable
             _manager.CurrentSessionChanged -= Manager_CurrentSessionChanged;
             _manager.SessionsChanged -= Manager_SessionsChanged;
         }
+
+        _currentSession = null;
+        _manager = null;
+        _publishStateLock.Dispose();
+    }
+
+    private static GlobalSystemMediaTransportControlsSession? GetCurrentOrFirstSession(GlobalSystemMediaTransportControlsSessionManager manager)
+    {
+        var currentSession = manager.GetCurrentSession();
+        if (currentSession is not null)
+        {
+            return currentSession;
+        }
+
+        var sessions = manager.GetSessions();
+        return sessions.Count > 0 ? sessions[0] : null;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
     }
 }

--- a/src/WindowsNotch.App/Services/MediaSessionService.cs
+++ b/src/WindowsNotch.App/Services/MediaSessionService.cs
@@ -278,7 +278,6 @@ public sealed class MediaSessionService : IDisposable
 
         _currentSession = null;
         _manager = null;
-        _publishStateLock.Dispose();
     }
 
     private static GlobalSystemMediaTransportControlsSession? GetCurrentOrFirstSession(GlobalSystemMediaTransportControlsSessionManager manager)

--- a/src/WindowsNotch.App/Services/ShelfService.cs
+++ b/src/WindowsNotch.App/Services/ShelfService.cs
@@ -6,7 +6,7 @@ using WindowsNotch.App.Models;
 
 namespace WindowsNotch.App.Services;
 
-public sealed class ShelfService
+public sealed class ShelfService(ICloudDriveLocator iCloudDriveLocator)
 {
     private static readonly HashSet<string> SupportedThumbnailExtensions =
     [
@@ -17,22 +17,17 @@ public sealed class ShelfService
         ".gif",
     ];
 
-    private readonly ICloudDriveLocator _iCloudDriveLocator;
-
-    public ShelfService(ICloudDriveLocator iCloudDriveLocator)
-    {
-        _iCloudDriveLocator = iCloudDriveLocator;
-    }
-
     public IReadOnlyList<ShelfItem> LoadItems()
     {
         Directory.CreateDirectory(AppPaths.ShelfRoot);
 
-        return Directory
-            .EnumerateFileSystemEntries(AppPaths.ShelfRoot)
-            .Select(CreateShelfItem)
-            .OrderByDescending(item => item.AddedAtUtc)
-            .ToList();
+        return
+        [
+            .. Directory
+                .EnumerateFileSystemEntries(AppPaths.ShelfRoot)
+                .Select(CreateShelfItem)
+                .OrderByDescending(item => item.AddedAtUtc),
+        ];
     }
 
     public Task<IReadOnlyList<ShelfItem>> StashEntriesAsync(IEnumerable<string> entryPaths, CancellationToken cancellationToken = default)
@@ -61,7 +56,7 @@ public sealed class ShelfService
     {
         return Task.Run(() =>
         {
-            if (!_iCloudDriveLocator.TryResolveWindowsNotchFolder(out var destinationFolder))
+            if (!iCloudDriveLocator.TryResolveWindowsNotchFolder(out var destinationFolder))
             {
                 return new CopyResult(
                     false,

--- a/src/WindowsNotch.App/Services/StartupRegistrationService.cs
+++ b/src/WindowsNotch.App/Services/StartupRegistrationService.cs
@@ -12,7 +12,8 @@ public sealed class StartupRegistrationService
     {
         using var runKey = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
         var registeredValue = runKey?.GetValue(AppValueName) as string;
-        return !string.IsNullOrWhiteSpace(registeredValue);
+        return !string.IsNullOrWhiteSpace(registeredValue) &&
+               string.Equals(registeredValue, BuildStartupValue(), StringComparison.OrdinalIgnoreCase);
     }
 
     public void SetEnabled(bool enabled)
@@ -26,12 +27,17 @@ public sealed class StartupRegistrationService
             return;
         }
 
+        runKey.SetValue(AppValueName, BuildStartupValue(), RegistryValueKind.String);
+    }
+
+    private static string BuildStartupValue()
+    {
         var executablePath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
         if (string.IsNullOrWhiteSpace(executablePath))
         {
             throw new InvalidOperationException("The current executable path could not be resolved.");
         }
 
-        runKey.SetValue(AppValueName, $"\"{executablePath}\"");
+        return $"\"{executablePath}\"";
     }
 }

--- a/src/WindowsNotch.App/Views/MainWindow.Animation.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.Animation.cs
@@ -29,8 +29,6 @@ public partial class MainWindow
             (!_isCollapseAnimationActive && IsCursorOverNotchBody(cursorPoint)) ||
             isExpandedAreaInteractive ||
             isPostDropHoldInteractive;
-        var isInteractive = isDragInteractive || isHoverInteractive;
-
         if (_isWaitingForPostDropExit)
         {
             RefreshOverlayMode(isInteractive: true);
@@ -54,14 +52,17 @@ public partial class MainWindow
             _keepExpandedUntilUtc = null;
         }
 
-        RefreshOverlayMode(isInteractive);
-
         if (isDragInteractive)
         {
             _hoverStartedUtc = null;
             _keepExpandedUntilUtc = null;
             _lastInteractiveUtc = now;
-            SetExpansionStage(NotchExpansionStage.Expanded);
+
+            if (!SetExpansionStage(NotchExpansionStage.Expanded))
+            {
+                RefreshOverlayMode(isInteractive: true);
+            }
+
             return;
         }
 
@@ -76,7 +77,11 @@ public partial class MainWindow
                 ? NotchExpansionStage.Expanded
                 : NotchExpansionStage.Preview;
 
-            SetExpansionStage(targetStage);
+            if (!SetExpansionStage(targetStage))
+            {
+                RefreshOverlayMode(isInteractive: true);
+            }
+
             return;
         }
 
@@ -84,6 +89,7 @@ public partial class MainWindow
 
         if (!IsPresented)
         {
+            RefreshOverlayMode(isInteractive: false);
             return;
         }
 
@@ -99,10 +105,14 @@ public partial class MainWindow
 
         if (now - _lastInteractiveUtc < TimeSpan.FromMilliseconds(CollapseDelayMilliseconds))
         {
+            RefreshOverlayMode(isInteractive: false);
             return;
         }
 
-        SetExpansionStage(NotchExpansionStage.Collapsed);
+        if (!SetExpansionStage(NotchExpansionStage.Collapsed))
+        {
+            RefreshOverlayMode(isInteractive: false);
+        }
     }
 
     private void TopmostTimer_Tick(object? sender, EventArgs e)
@@ -132,7 +142,7 @@ public partial class MainWindow
         UpdateOverlayMode(overlayModeActive, immediateTopUpdate: true);
     }
 
-    private bool IsCursorInHotZone(Point cursorPoint)
+    private static bool IsCursorInHotZone(Point cursorPoint)
     {
         var centerX = SystemParameters.PrimaryScreenWidth / 2.0;
         return cursorPoint.Y <= HotZoneHeight && Math.Abs(cursorPoint.X - centerX) <= HotZoneHalfWidth;
@@ -168,18 +178,18 @@ public partial class MainWindow
                cursorPoint.Y <= windowBottom;
     }
 
-    private void SetExpansionStage(NotchExpansionStage stage)
+    private bool SetExpansionStage(NotchExpansionStage stage)
     {
         if (stage == NotchExpansionStage.Collapsed &&
             _keepExpandedUntilUtc is DateTime keepExpandedUntilUtc &&
             DateTime.UtcNow < keepExpandedUntilUtc)
         {
-            return;
+            return false;
         }
 
         if (_expansionStage == stage)
         {
-            return;
+            return false;
         }
 
         var previousStage = _expansionStage;
@@ -189,13 +199,13 @@ public partial class MainWindow
         {
             case NotchExpansionStage.Preview:
                 TransitionToPreview();
-                return;
+                return true;
             case NotchExpansionStage.Expanded:
                 TransitionToExpanded(previousStage);
-                return;
+                return true;
             default:
                 TransitionToCollapsed(previousStage);
-                return;
+                return true;
         }
     }
 
@@ -505,7 +515,7 @@ public partial class MainWindow
         return geometry;
     }
 
-    private double GetCollapsedScaleX()
+    private static double GetCollapsedScaleX()
     {
         var collapsedBodyWidth = CollapsedWidth - (WindowHorizontalMargin * 2.0);
         var expandedBodyWidth = ExpandedWidth - (WindowHorizontalMargin * 2.0);
@@ -521,7 +531,7 @@ public partial class MainWindow
             : collapsedBodyHeight / expandedBodyHeight;
     }
 
-    private double GetPreviewScaleX()
+    private static double GetPreviewScaleX()
     {
         var collapsedScaleX = GetCollapsedScaleX();
         return collapsedScaleX + ((1.0 - collapsedScaleX) * PreviewScaleProgress);

--- a/src/WindowsNotch.App/Views/MainWindow.DragAndShelf.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.DragAndShelf.cs
@@ -241,11 +241,6 @@ public partial class MainWindow
         return true;
     }
 
-    private void LoadShelfItems()
-    {
-        ReplaceShelfItems(_shelfService.LoadItems());
-    }
-
     private void ReplaceShelfItems(IEnumerable<ShelfItem> items)
     {
         var selectedPath = _selectedShelfItem?.StoredPath;
@@ -274,23 +269,23 @@ public partial class MainWindow
     private void UpdateDropZoneVisuals()
     {
         ShareDropZone.Background = _isShareDropTargetActive
-            ? new SolidColorBrush(Color.FromArgb(54, 72, 137, 255))
-            : new SolidColorBrush(Color.FromArgb(255, 0, 0, 0));
+            ? DropZoneActiveBackgroundBrush
+            : DropZoneIdleBackgroundBrush;
 
         ShareDropZone.BorderBrush = _isShareDropTargetActive
-            ? new SolidColorBrush(Color.FromArgb(120, 126, 184, 255))
+            ? DropZoneActiveBorderBrush
             : Brushes.Transparent;
 
         EmptyShelfPanel.Background = _isShelfDropTargetActive
-            ? new SolidColorBrush(Color.FromArgb(54, 72, 137, 255))
-            : new SolidColorBrush(Color.FromArgb(255, 0, 0, 0));
+            ? DropZoneActiveBackgroundBrush
+            : DropZoneIdleBackgroundBrush;
 
         EmptyShelfPanel.BorderBrush = _isShelfDropTargetActive
-            ? new SolidColorBrush(Color.FromArgb(120, 126, 184, 255))
+            ? DropZoneActiveBorderBrush
             : Brushes.Transparent;
 
         ShelfPanel.BorderBrush = _isShelfDropTargetActive
-            ? new SolidColorBrush(Color.FromArgb(90, 102, 209, 255))
+            ? ShelfPanelActiveBorderBrush
             : Brushes.Transparent;
     }
 

--- a/src/WindowsNotch.App/Views/MainWindow.Interop.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.Interop.cs
@@ -25,51 +25,51 @@ public partial class MainWindow
         return transform.Value.Transform(new Point(point.X, point.Y));
     }
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetCursorPos(out NativePoint point);
+    private static partial bool GetCursorPos(out NativePoint point);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetForegroundWindow();
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsWindowVisible(IntPtr hWnd);
+    private static partial bool IsWindowVisible(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsIconic(IntPtr hWnd);
+    private static partial bool IsIconic(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetWindowRect(IntPtr hWnd, out NativeRect lpRect);
+    private static partial bool GetWindowRect(IntPtr hWnd, out NativeRect lpRect);
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
-    [DllImport("user32.dll")]
-    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+    [LibraryImport("user32.dll")]
+    private static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
-    [DllImport("dwmapi.dll")]
-    private static extern int DwmGetWindowAttribute(
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmGetWindowAttribute(
         IntPtr hwnd,
         int dwAttribute,
         out NativeRect pvAttribute,
         int cbAttribute);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
 
-    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MonitorInfo lpmi);
+    private static partial bool GetMonitorInfo(IntPtr hMonitor, ref MonitorInfo lpmi);
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowPos(
+    private static partial bool SetWindowPos(
         IntPtr hWnd,
         IntPtr hWndInsertAfter,
         int X,
@@ -78,17 +78,17 @@ public partial class MainWindow
         int cy,
         uint uFlags);
 
-    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
-    private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static partial IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
 
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
-    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static partial IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
-    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
-    private static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static partial int GetWindowLong32(IntPtr hWnd, int nIndex);
 
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
-    private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static partial int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
 
     private static readonly IntPtr HWND_TOPMOST = new(-1);
     private static readonly IntPtr HWND_NOTOPMOST = new(-2);
@@ -172,8 +172,8 @@ public partial class MainWindow
             return false;
         }
 
-        GetWindowThreadProcessId(windowHandle, out var processId);
-        return processId == Environment.ProcessId;
+        var threadId = GetWindowThreadProcessId(windowHandle, out var processId);
+        return threadId != 0 && processId == Environment.ProcessId;
     }
 
     private static bool IsIgnoredOverlayWindowClass(string className)

--- a/src/WindowsNotch.App/Views/MainWindow.SettingsOverlay.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.SettingsOverlay.cs
@@ -67,7 +67,7 @@ public partial class MainWindow
 
     private void RefreshOverlayModeForCurrentState(bool immediateTopUpdate = false)
     {
-        RefreshOverlayMode(isInteractive: false, immediateTopUpdate);
+        RefreshOverlayMode(GetCurrentOverlayInteractivity(), immediateTopUpdate);
     }
 
     private void RefreshOverlayMode(bool isInteractive, bool immediateTopUpdate = false)
@@ -274,5 +274,18 @@ public partial class MainWindow
         }
 
         SetCurrentValue(TopProperty, top);
+    }
+
+    private bool GetCurrentOverlayInteractivity()
+    {
+        if (_isDragOver || _isShareDropTargetActive || _isShelfDropTargetActive || _isWaitingForPostDropExit)
+        {
+            return true;
+        }
+
+        var cursorPoint = GetCursorPositionInDeviceIndependentPixels();
+        return IsCursorInHotZone(cursorPoint) ||
+               (!_isCollapseAnimationActive && IsCursorOverNotchBody(cursorPoint)) ||
+               (IsExpanded && !_isCollapseAnimationActive && IsCursorOverExpandedWindow(cursorPoint));
     }
 }

--- a/src/WindowsNotch.App/Views/MainWindow.xaml.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.xaml.cs
@@ -49,6 +49,13 @@ public partial class MainWindow : Window
     private const int ModeSwitchPressTimeoutMilliseconds = 600;
     private const double PreviewScaleProgress = 0.12;
     private const double PreviewHeightMultiplier = 1.08;
+    private static readonly Brush ShareStatusIdleBackgroundBrush = CreateFrozenBrush(Color.FromArgb(18, 255, 255, 255));
+    private static readonly Brush ShareStatusSuccessBackgroundBrush = CreateFrozenBrush(Color.FromArgb(255, 170, 235, 120));
+    private static readonly Brush ShareStatusSuccessForegroundBrush = CreateFrozenBrush(Color.FromArgb(255, 22, 51, 0));
+    private static readonly Brush DropZoneIdleBackgroundBrush = CreateFrozenBrush(Color.FromArgb(255, 0, 0, 0));
+    private static readonly Brush DropZoneActiveBackgroundBrush = CreateFrozenBrush(Color.FromArgb(54, 72, 137, 255));
+    private static readonly Brush DropZoneActiveBorderBrush = CreateFrozenBrush(Color.FromArgb(120, 126, 184, 255));
+    private static readonly Brush ShelfPanelActiveBorderBrush = CreateFrozenBrush(Color.FromArgb(90, 102, 209, 255));
 
     private readonly DispatcherTimer _hoverTimer;
     private readonly DispatcherTimer _topmostTimer;
@@ -127,6 +134,7 @@ public partial class MainWindow : Window
         _collapseAnimationTimer.Tick += CollapseAnimationTimer_Tick;
         _shareStatusResetTimer.Tick += ShareStatusResetTimer_Tick;
         SourceInitialized += Window_SourceInitialized;
+        Closed += Window_Closed;
     }
 
     private async void Window_Loaded(object sender, RoutedEventArgs e)
@@ -136,7 +144,7 @@ public partial class MainWindow : Window
         ApplyImmediateNotchScale(GetCollapsedScaleX(), 1.0);
         UpdateExpandedModePresentation();
 
-        LoadShelfItems();
+        await LoadShelfItemsAsync();
         UpdateDropZoneVisuals();
         PositionWindow();
         SetShareStatusIdle();
@@ -250,7 +258,7 @@ public partial class MainWindow : Window
     private void SetShareStatusIdle()
     {
         _shareStatusResetTimer.Stop();
-        ShareStatusBadge.Background = new SolidColorBrush(Color.FromArgb(18, 255, 255, 255));
+        ShareStatusBadge.Background = ShareStatusIdleBackgroundBrush;
         ShareCloudIcon.Visibility = Visibility.Visible;
         ShareSuccessIcon.Visibility = Visibility.Collapsed;
         ShareStatusText.Text = "iCloud Drive";
@@ -259,11 +267,11 @@ public partial class MainWindow : Window
 
     private void SetShareStatusSuccess()
     {
-        ShareStatusBadge.Background = new SolidColorBrush(Color.FromArgb(255, 170, 235, 120));
+        ShareStatusBadge.Background = ShareStatusSuccessBackgroundBrush;
         ShareCloudIcon.Visibility = Visibility.Collapsed;
         ShareSuccessIcon.Visibility = Visibility.Visible;
         ShareStatusText.Text = "Added";
-        ShareStatusText.Foreground = new SolidColorBrush(Color.FromArgb(255, 185, 255, 150));
+        ShareStatusText.Foreground = ShareStatusSuccessForegroundBrush;
         _shareStatusResetTimer.Stop();
         _shareStatusResetTimer.Start();
     }
@@ -304,5 +312,39 @@ public partial class MainWindow : Window
             MusicModeButton.Opacity = isFilesMode ? 0.52 : 1.0;
             MusicModeButton.IsHitTestVisible = isFilesMode;
         }
+    }
+
+    private async Task LoadShelfItemsAsync()
+    {
+        var items = await Task.Run(_shelfService.LoadItems);
+        ReplaceShelfItems(items);
+    }
+
+    private void Window_Closed(object? sender, EventArgs e)
+    {
+        SourceInitialized -= Window_SourceInitialized;
+        Closed -= Window_Closed;
+
+        _hoverTimer.Stop();
+        _topmostTimer.Stop();
+        _collapseAnimationTimer.Stop();
+        _shareStatusResetTimer.Stop();
+        _musicProgressTimer.Stop();
+
+        _hoverTimer.Tick -= HoverTimer_Tick;
+        _topmostTimer.Tick -= TopmostTimer_Tick;
+        _collapseAnimationTimer.Tick -= CollapseAnimationTimer_Tick;
+        _shareStatusResetTimer.Tick -= ShareStatusResetTimer_Tick;
+        _musicProgressTimer.Tick -= MusicProgressTimer_Tick;
+
+        _mediaSessionService.StateChanged -= MediaSessionService_StateChanged;
+        _mediaSessionService.Dispose();
+    }
+
+    private static SolidColorBrush CreateFrozenBrush(Color color)
+    {
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
     }
 }

--- a/src/WindowsNotch.App/Views/MainWindow.xaml.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.xaml.cs
@@ -143,12 +143,12 @@ public partial class MainWindow : Window
         Height = CollapsedHeight;
         ApplyImmediateNotchScale(GetCollapsedScaleX(), 1.0);
         UpdateExpandedModePresentation();
-
-        await LoadShelfItemsAsync();
         UpdateDropZoneVisuals();
         PositionWindow();
         SetShareStatusIdle();
         _hoverTimer.Start();
+
+        await LoadShelfItemsAsync();
         await InitializeMediaSessionAsync();
     }
 

--- a/src/WindowsNotch.App/Views/SettingsWindow.xaml.cs
+++ b/src/WindowsNotch.App/Views/SettingsWindow.xaml.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Media3D;
+using System.Windows.Controls.Primitives;
 using WindowsNotch.App.Models;
 using WindowsNotch.App.Services;
 
@@ -19,7 +21,7 @@ public partial class SettingsWindow : Window
 
         _iCloudDriveLocator = iCloudDriveLocator;
         LaunchAtStartupCheckBox.IsChecked = settings.LaunchAtStartup;
-        UpdateWindowClip();
+        Loaded += Window_Loaded;
     }
 
     public bool ShouldExitAfterClose { get; private set; }
@@ -46,24 +48,31 @@ public partial class SettingsWindow : Window
 
     private void OpenICloudFolderButton_Click(object sender, RoutedEventArgs e)
     {
-        if (!_iCloudDriveLocator.TryResolveWindowsNotchFolder(out var folderPath))
+        try
         {
-            MessageBox.Show(
-                this,
-                "iCloud Drive was not found. Turn it on in iCloud for Windows first.",
-                "WindowsNotch",
-                MessageBoxButton.OK,
-                MessageBoxImage.Warning);
-            return;
+            if (!_iCloudDriveLocator.TryResolveWindowsNotchFolder(out var folderPath))
+            {
+                MessageBox.Show(
+                    this,
+                    "iCloud Drive was not found. Turn it on in iCloud for Windows first.",
+                    "WindowsNotch",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
+
+            Directory.CreateDirectory(folderPath);
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = folderPath,
+                UseShellExecute = true,
+            });
         }
-
-        Directory.CreateDirectory(folderPath);
-
-        Process.Start(new ProcessStartInfo
+        catch (Exception ex)
         {
-            FileName = folderPath,
-            UseShellExecute = true,
-        });
+            MessageBox.Show(this, ex.Message, "WindowsNotch", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 
     private void CloseChromeButton_Click(object sender, RoutedEventArgs e)
@@ -84,12 +93,17 @@ public partial class SettingsWindow : Window
 
     private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        if (e.ChangedButton != MouseButton.Left)
+        if (e.ChangedButton != MouseButton.Left || ShouldIgnoreWindowDrag(e.OriginalSource as DependencyObject))
         {
             return;
         }
 
         DragMove();
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        UpdateWindowClip();
     }
 
     private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -108,5 +122,25 @@ public partial class SettingsWindow : Window
             new Rect(0, 0, WindowSurfaceBorder.ActualWidth, WindowSurfaceBorder.ActualHeight),
             SurfaceCornerRadius,
             SurfaceCornerRadius);
+    }
+
+    private static bool ShouldIgnoreWindowDrag(DependencyObject? source)
+    {
+        while (source is not null)
+        {
+            if (source is ButtonBase or Thumb)
+            {
+                return true;
+            }
+
+            source = source switch
+            {
+                Visual visual => VisualTreeHelper.GetParent(visual),
+                Visual3D visual3D => VisualTreeHelper.GetParent(visual3D),
+                _ => null,
+            };
+        }
+
+        return false;
     }
 }

--- a/src/WindowsNotch.App/Views/ShareGuideWindow.xaml.cs
+++ b/src/WindowsNotch.App/Views/ShareGuideWindow.xaml.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Media3D;
+using System.Windows.Controls.Primitives;
 
 namespace WindowsNotch.App;
 
@@ -12,7 +14,7 @@ public partial class ShareGuideWindow : Window
     {
         InitializeComponent();
         FolderPathTextBlock.Text = folderPathText;
-        UpdateWindowClip();
+        Loaded += Window_Loaded;
     }
 
     private void OkButton_Click(object sender, RoutedEventArgs e)
@@ -27,12 +29,17 @@ public partial class ShareGuideWindow : Window
 
     private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        if (e.ChangedButton != MouseButton.Left)
+        if (e.ChangedButton != MouseButton.Left || ShouldIgnoreWindowDrag(e.OriginalSource as DependencyObject))
         {
             return;
         }
 
         DragMove();
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        UpdateWindowClip();
     }
 
     private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -51,5 +58,25 @@ public partial class ShareGuideWindow : Window
             new Rect(0, 0, WindowSurfaceBorder.ActualWidth, WindowSurfaceBorder.ActualHeight),
             SurfaceCornerRadius,
             SurfaceCornerRadius);
+    }
+
+    private static bool ShouldIgnoreWindowDrag(DependencyObject? source)
+    {
+        while (source is not null)
+        {
+            if (source is ButtonBase or Thumb)
+            {
+                return true;
+            }
+
+            source = source switch
+            {
+                Visual visual => VisualTreeHelper.GetParent(visual),
+                Visual3D visual3D => VisualTreeHelper.GetParent(visual3D),
+                _ => null,
+            };
+        }
+
+        return false;
     }
 }

--- a/src/WindowsNotch.App/WindowsNotch.App.csproj
+++ b/src/WindowsNotch.App/WindowsNotch.App.csproj
@@ -5,6 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>WindowsNotch.App</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>


### PR DESCRIPTION
## Related
- Closes #12

## Summary
- harden startup/runtime crash handling and crash log writing so secondary failures do not cascade
- serialize media session refreshes, stale state suppression, and disposal cleanup for more stable now-playing updates
- tighten notch hover / overlay handoff so collapse and hide transitions are less likely to flicker or mis-hide during interaction
- save settings atomically, validate startup registration against the current executable path, and polish settings/share window interaction guards
- modernize a few core implementation details with frozen shared brushes, async shelf loading, `LibraryImport`, and smaller cleanup around animation state handling

## Testing
- `C:\Users\user\.dotnet\dotnet.exe build .\WindowsNotch.sln`
- `C:\Users\user\.dotnet\dotnet.exe build .\WindowsNotch.sln -c Release`

## UI Notes
- notch overlay visibility and hover expansion timing were adjusted with small, targeted changes rather than a full animation rewrite
- collapse / hide behavior and post-drop interaction retention were kept compatible with the current WPF notch flow
- settings and share guide windows now avoid accidental drag-move when interacting with buttons and controls

## Attribution
Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced crash error handling and reporting to prevent re-entrancy during failures.
  * Fixed window drag behavior to prevent unintended dragging when clicking interactive controls.
  * Improved error messages when opening iCloud folder operations.

* **Improvements**
  * Refined drag-drop zone styling consistency.
  * Enhanced shelf item loading and async performance.
  * Optimized window lifecycle cleanup to prevent memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->