### PR TITLE
fix: restore startup after GetMonitorInfo crash

### DIFF
--- a/src/WindowsNotch.App/Views/MainWindow.Interop.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.Interop.cs
@@ -63,7 +63,7 @@ public partial class MainWindow
     [LibraryImport("user32.dll")]
     private static partial IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
 
-    [LibraryImport("user32.dll")]
+    [LibraryImport("user32.dll", EntryPoint = "GetMonitorInfoW")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool GetMonitorInfo(IntPtr hMonitor, ref MonitorInfo lpmi);
 


### PR DESCRIPTION
## Related
- Closes #14

## Summary
- fix the `GetMonitorInfo` P/Invoke declaration so startup overlay initialization no longer crashes immediately
- point the generated interop call at `GetMonitorInfoW`, which restores successful app launch on the current WPF build

## Testing
- `C:\Users\user\.dotnet\dotnet.exe build .\WindowsNotch.sln` after stopping the running app process
- app launch verification from `src\WindowsNotch.App\bin\Debug\net8.0-windows10.0.19041.0\WindowsNotch.App.exe`

## UI Notes
- no intended notch animation or layout behavior change
- this is a startup stability fix only

## Attribution
Generated with Codex