### PR TITLE
refactor: polish notch motion transitions

### DIFF
--- a/src/WindowsNotch.App/Views/MainWindow.Animation.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.Animation.cs
@@ -137,6 +137,8 @@ public partial class MainWindow
 
         ApplyWindowBounds(GetWindowLeft(ExpandedWidth), collapsedTop, ExpandedWidth, CollapsedHeight);
         ApplyImmediateNotchScale(GetCollapsedScaleX(), 1.0);
+        HideExpandedContentImmediately();
+        SettingsButton.Visibility = Visibility.Collapsed;
         UpdateExpandedModePresentation();
 
         UpdateOverlayMode(overlayModeActive, immediateTopUpdate: true);
@@ -225,7 +227,7 @@ public partial class MainWindow
         AnimateNotchScale(
             GetPreviewScaleX(),
             GetPreviewCollapsedScaleY(),
-            ExpandAnimationMilliseconds);
+            PreviewAnimationMilliseconds);
     }
 
     private void TransitionToExpanded(NotchExpansionStage previousStage)
@@ -244,19 +246,18 @@ public partial class MainWindow
 
         RefreshOverlayMode(isInteractive: true, immediateTopUpdate: true);
         AnimateNotchScale(1.0, 1.0, ExpandAnimationMilliseconds);
-        AnimateExpandedContentIn(ExpandAnimationMilliseconds);
+        AnimateExpandedContentIn(ExpandedContentEnterAnimationMilliseconds);
     }
 
     private void TransitionToCollapsed(NotchExpansionStage previousStage)
     {
-        SettingsButton.Visibility = Visibility.Collapsed;
-        UpdateExpandedModePresentation();
-
         if (previousStage == NotchExpansionStage.Expanded)
         {
             _isCollapseAnimationActive = true;
             _pendingCollapseOverlayModeActive = ShouldDisplayOverlayAfterCollapse();
             _collapseAnimationTimer.Stop();
+            SettingsButton.Visibility = Visibility.Visible;
+            UpdateExpandedModePresentation();
 
             if (_pendingCollapseOverlayModeActive == false)
             {
@@ -267,7 +268,7 @@ public partial class MainWindow
             }
 
             _collapseAnimationTimer.Start();
-            HideExpandedContentImmediately();
+            AnimateExpandedContentOut(ExpandedContentExitAnimationMilliseconds);
             RefreshOverlayMode(
                 isInteractive: _isDragOver || _isShareDropTargetActive || _isShelfDropTargetActive,
                 immediateTopUpdate: false);
@@ -279,6 +280,8 @@ public partial class MainWindow
         _pendingCollapseOverlayModeActive = null;
         _collapseAnimationTimer.Stop();
 
+        SettingsButton.Visibility = Visibility.Collapsed;
+        UpdateExpandedModePresentation();
         HideExpandedContentImmediately();
         ApplyWindowBounds(GetWindowLeft(ExpandedWidth), GetWindowTop(overlayModeActive: true), ExpandedWidth, CollapsedHeight);
         RefreshOverlayMode(isInteractive: false, immediateTopUpdate: false);
@@ -395,10 +398,9 @@ public partial class MainWindow
         {
             EasingMode = EasingMode.EaseOut,
         });
-        AnimateElementDimension(NotchScaleTransform, ScaleTransform.ScaleYProperty, targetScaleY, durationMilliseconds, new ExponentialEase
+        AnimateElementDimension(NotchScaleTransform, ScaleTransform.ScaleYProperty, targetScaleY, durationMilliseconds, new QuinticEase
         {
             EasingMode = EasingMode.EaseOut,
-            Exponent = 5,
         });
     }
 
@@ -412,14 +414,34 @@ public partial class MainWindow
         {
             EasingMode = EasingMode.EaseOut,
         });
-        AnimateElementDimension(ExpandedContentScaleTransform, ScaleTransform.ScaleYProperty, 1.0, durationMilliseconds, new ExponentialEase
+        AnimateElementDimension(ExpandedContentScaleTransform, ScaleTransform.ScaleYProperty, 1.0, durationMilliseconds, new QuarticEase
         {
             EasingMode = EasingMode.EaseOut,
-            Exponent = 5,
         });
         AnimateElementDimension(ExpandedContentTranslateTransform, TranslateTransform.YProperty, 0.0, durationMilliseconds, new CubicEase
         {
             EasingMode = EasingMode.EaseOut,
+        });
+    }
+
+    private void AnimateExpandedContentOut(int durationMilliseconds)
+    {
+        ExpandedContentViewport.Height = _expandedContentHeight;
+        AnimateElementDimension(ExpandedContentViewport, UIElement.OpacityProperty, 0.0, durationMilliseconds, new QuadraticEase
+        {
+            EasingMode = EasingMode.EaseIn,
+        });
+        AnimateElementDimension(ExpandedContentScaleTransform, ScaleTransform.ScaleXProperty, 0.985, durationMilliseconds, new CubicEase
+        {
+            EasingMode = EasingMode.EaseIn,
+        });
+        AnimateElementDimension(ExpandedContentScaleTransform, ScaleTransform.ScaleYProperty, 0.94, durationMilliseconds, new CubicEase
+        {
+            EasingMode = EasingMode.EaseIn,
+        });
+        AnimateElementDimension(ExpandedContentTranslateTransform, TranslateTransform.YProperty, -4.0, durationMilliseconds, new CubicEase
+        {
+            EasingMode = EasingMode.EaseIn,
         });
     }
 

--- a/src/WindowsNotch.App/Views/MainWindow.xaml.cs
+++ b/src/WindowsNotch.App/Views/MainWindow.xaml.cs
@@ -36,8 +36,11 @@ public partial class MainWindow : Window
     private const double HiddenRevealHeight = 0;
     private const double HotZoneHeight = 6;
     private const double HotZoneHalfWidth = 188;
-    private const int ExpandAnimationMilliseconds = 280;
-    private const int CollapseAnimationMilliseconds = 240;
+    private const int PreviewAnimationMilliseconds = 190;
+    private const int ExpandAnimationMilliseconds = 260;
+    private const int CollapseAnimationMilliseconds = 230;
+    private const int ExpandedContentEnterAnimationMilliseconds = 220;
+    private const int ExpandedContentExitAnimationMilliseconds = 170;
     private const int HoverPollMilliseconds = 16;
     private const int PreviewExpandDelayMilliseconds = 220;
     private const int CollapseDelayMilliseconds = 180;
@@ -95,6 +98,7 @@ public partial class MainWindow : Window
 
     private bool IsExpanded => _expansionStage == NotchExpansionStage.Expanded;
     private bool IsPresented => _expansionStage != NotchExpansionStage.Collapsed;
+    private bool ShouldShowExpandedChrome => IsExpanded || _isCollapseAnimationActive;
 
     public MainWindow()
     {
@@ -285,6 +289,7 @@ public partial class MainWindow : Window
     private void UpdateExpandedModePresentation()
     {
         var isFilesMode = _expandedMode == ExpandedMode.Files;
+        var showExpandedChrome = ShouldShowExpandedChrome;
 
         if (FilesView is not null)
         {
@@ -298,7 +303,7 @@ public partial class MainWindow : Window
 
         if (ModeSwitchPanel is not null)
         {
-            ModeSwitchPanel.Visibility = IsExpanded ? Visibility.Visible : Visibility.Collapsed;
+            ModeSwitchPanel.Visibility = showExpandedChrome ? Visibility.Visible : Visibility.Collapsed;
         }
 
         if (FilesModeButton is not null)


### PR DESCRIPTION
## Related
- Closes #16

## Summary
- keep the expanded top chrome visible through the collapse handoff so close motion feels less abrupt
- animate the expanded content out instead of hiding it instantly at the start of collapse
- split preview timing from full expand timing and slightly retune the notch easing for a smoother overall motion

## Testing
- `C:\Users\user\.dotnet\dotnet.exe build .\WindowsNotch.sln`
- manual app launch from `src\WindowsNotch.App\bin\Debug\net8.0-windows10.0.19041.0\WindowsNotch.App.exe`

## UI Notes
- no feature behavior change intended beyond motion polish
- preview, expanded, and collapse transitions were tuned with small WPF animation changes only
- collapse now keeps chrome visible until the end of the closing handoff and fades content out instead of popping it away

## Attribution
Generated with Codex